### PR TITLE
Burnseverity Metrics

### DIFF
--- a/alfresco_postprocessing/__init__.py
+++ b/alfresco_postprocessing/__init__.py
@@ -151,6 +151,7 @@ def _run_timestep( timestep, sub_domains, veg_name_dict, *args, **kwargs ):
 	ds_fs = ap.open( timestep.FireScar.fn, sub_domains=sub_domains )
 	ds_veg = ap.open( timestep.Veg.fn, sub_domains=sub_domains )
 	# ds_age = ap.open( timestep.Age.fn, sub_domains=sub_domains )
+	ds_burnseverity = ap.open( timestep.BurnSeverity.fn, sub_domains=sub_domains )
 	
 	out_dd = {}
 	# fire 
@@ -167,6 +168,9 @@ def _run_timestep( timestep, sub_domains, veg_name_dict, *args, **kwargs ):
 
 	# age -- not yet implemented
 	# age = Age()
+
+	burnseverity = BurnSeverity( ds_burnseverity )
+	out_dd.update( severity_counts=burnseverity.severity_counts )
 	return out_dd
 
 def _get_stats( timesteps, db, sub_domains, ncores, veg_name_dict ):

--- a/alfresco_postprocessing/metrics.py
+++ b/alfresco_postprocessing/metrics.py
@@ -159,7 +159,7 @@ class BurnSeverity( object ):
 		Arguments:
 		----------
 		alf_ds = (AlfrescoDataset) an object of type AlfrescoDataset which contains
-				all needed attributes to run the fire metrics.
+				all needed attributes to run the burn_severity metrics.
 
 		returns:
 		--------
@@ -178,5 +178,5 @@ class BurnSeverity( object ):
 		raster_arr = self.alf_ds.raster_arr
 		return { self.alf_ds.sub_domains.names_dict[domain_num]:\
 					dict( zip( *np.unique( raster_arr[ (domain == domain_num) & (raster_arr > 0) & (raster_arr != 255) ], return_counts=True ) ) ) \
-					for domain_num, domain in domains } # changed (raster_arr > 0) from (raster_arr >= 0)  WATCH IT!
+					for domain_num, domain in domains }
 

--- a/alfresco_postprocessing/metrics.py
+++ b/alfresco_postprocessing/metrics.py
@@ -144,3 +144,39 @@ class VegFire( object ):
 					for domain_num, domain in domains } # changed (raster_arr > 0) from (raster_arr >= 0)  WATCH IT!
 
 
+class BurnSeverity( object ):
+	'''
+	[ experimental ]
+	calculate BurnSeverity metrics from ALFRESCO Fire Dynamics Model 
+	output rasters across subdomains if applicable.
+	'''
+	def __init__( self, alf_ds, **kwargs ):
+		'''
+		initialize BurnSeverity data and calculate metrics
+
+		severity_counts = counts of unique burn severity levels in a given subdomain
+
+		Arguments:
+		----------
+		alf_ds = (AlfrescoDataset) an object of type AlfrescoDataset which contains
+				all needed attributes to run the fire metrics.
+
+		returns:
+		--------
+		object of class AlfrescoFire containing attributes calculated over the raster
+		and potentially the subdomains in that area of interest.
+
+		'''
+		self.alf_ds = alf_ds
+		self.severity_counts = self._unique_counts_domains( )
+
+	def _total_area_burned( self, *args, **kwargs ):
+		return { i:np.sum( self.fire_counts[ i ].values() ) for i in self.fire_counts.keys() }
+	def _unique_counts_domains( self ):
+		domains = self.alf_ds.sub_domains.sub_domains
+		domains = [ (np.unique( domain[domain > 0] )[0], domain) for domain in domains ]
+		raster_arr = self.alf_ds.raster_arr
+		return { self.alf_ds.sub_domains.names_dict[domain_num]:\
+					dict( zip( *np.unique( raster_arr[ (domain == domain_num) & (raster_arr > 0) ], return_counts=True ) ) ) \
+					for domain_num, domain in domains } # changed (raster_arr > 0) from (raster_arr >= 0)  WATCH IT!
+

--- a/alfresco_postprocessing/metrics.py
+++ b/alfresco_postprocessing/metrics.py
@@ -177,6 +177,6 @@ class BurnSeverity( object ):
 		domains = [ (np.unique( domain[domain > 0] )[0], domain) for domain in domains ]
 		raster_arr = self.alf_ds.raster_arr
 		return { self.alf_ds.sub_domains.names_dict[domain_num]:\
-					dict( zip( *np.unique( raster_arr[ (domain == domain_num) & (raster_arr > 0) ], return_counts=True ) ) ) \
+					dict( zip( *np.unique( raster_arr[ (domain == domain_num) & (raster_arr > 0) & (raster_arr != 255) ], return_counts=True ) ) ) \
 					for domain_num, domain in domains } # changed (raster_arr > 0) from (raster_arr >= 0)  WATCH IT!
 

--- a/alfresco_postprocessing/postprocess.py
+++ b/alfresco_postprocessing/postprocess.py
@@ -367,7 +367,7 @@ def metric_to_csvs( db, metric_name, output_path, suffix=None ):
 	endyear = max(years)
 
 	for domain in domains:
-		if metric_name != 'veg_counts': # fire
+		if metric_name not in ['veg_counts', 'severity_counts']: # firescar
 			if suffix == None:
 				output_filename = os.path.join( output_path, '_'.join([ 'alfresco', metric_name.replace('_',''), domain,\
 													startyear, endyear ]) + '.csv' )
@@ -381,7 +381,7 @@ def metric_to_csvs( db, metric_name, output_path, suffix=None ):
 			panel_select.columns = column_order_names
 			panel_select.to_csv( output_filename, sep=',' )
 
-		if metric_name == 'veg_counts': # veg
+		elif metric_name == 'veg_counts': # veg
 			df = panel[ :, domain, : ]
 			vegtypes = sorted( df.ix[0,0].keys() )
 			new_panel = pd.Panel( df.to_dict() )
@@ -401,6 +401,18 @@ def metric_to_csvs( db, metric_name, output_path, suffix=None ):
 				# deal with NaN's? !
 				veg_df.fillna( 0 )
 				veg_df.to_csv( output_filename, sep=',' )
+
+		elif metric_name == 'severity_counts':
+			burnseverity = { (rec[ 'replicate' ],rec[ 'fire_year' ]):pd.Series(rec[ 'severity_counts' ][ domain ]) for rec in db.all() }
+			df = pd.concat( burnseverity ).astype( int ).unstack().fillna( 0 )
+			if suffix == None:
+				output_filename = os.path.join( output_path, '_'.join([ 'alfresco', metric_name.replace('_',''), domain,\
+													startyear, endyear ]) + '.csv' )
+			else:
+				output_filename = os.path.join( output_path, '_'.join([ 'alfresco', metric_name.replace('_',''), domain,\
+													suffix, startyear, endyear ]) + '.csv' )
+			df.to_csv( output_filename, sep=',' )
+
 	return 1
 
 

--- a/alfresco_postprocessing/postprocess.py
+++ b/alfresco_postprocessing/postprocess.py
@@ -411,7 +411,7 @@ def metric_to_csvs( db, metric_name, output_path, suffix=None ):
 			else:
 				output_filename = os.path.join( output_path, '_'.join([ 'alfresco', metric_name.replace('_',''), domain,\
 													suffix, startyear, endyear ]) + '.csv' )
-			df.to_csv( output_filename, sep=',' )
+			df.to_csv( output_filename, sep=',', index_label=('replicate','year') )
 
 	return 1
 

--- a/alfresco_postprocessing/postprocess.py
+++ b/alfresco_postprocessing/postprocess.py
@@ -404,7 +404,7 @@ def metric_to_csvs( db, metric_name, output_path, suffix=None ):
 
 		elif metric_name == 'severity_counts':
 			burnseverity = { (rec[ 'replicate' ],rec[ 'fire_year' ]):pd.Series(rec[ 'severity_counts' ][ domain ]) for rec in db.all() }
-			df = pd.concat( burnseverity ).astype( int ).unstack().fillna( 0 )
+			df = pd.concat( burnseverity ).astype( int ).unstack().fillna( 0 ).astype( int )
 			if suffix == None:
 				output_filename = os.path.join( output_path, '_'.join([ 'alfresco', metric_name.replace('_',''), domain,\
 													startyear, endyear ]) + '.csv' )

--- a/example_run.py
+++ b/example_run.py
@@ -16,7 +16,7 @@ output_path = './ALFRESCO_PP'
 mod_json_fn = os.path.join( output_path, 'ALF.json' )
 obs_json_fn = os.path.join( output_path, 'OBS.json' )
 suffix = 'ModelName_scenario' # some id for the output csvs
-metrics = [ 'veg_counts','avg_fire_size','number_of_fires','all_fire_sizes','total_area_burned' ]
+metrics = [ 'veg_counts','avg_fire_size','number_of_fires','all_fire_sizes','total_area_burned','severity_counts' ]
 
 # # PostProcess
 # alfresco output gtiffs

--- a/example_run.py
+++ b/example_run.py
@@ -16,7 +16,7 @@ output_path = './ALFRESCO_PP'
 mod_json_fn = os.path.join( output_path, 'ALF.json' )
 obs_json_fn = os.path.join( output_path, 'OBS.json' )
 suffix = 'ModelName_scenario' # some id for the output csvs
-metrics = [ 'veg_counts','avg_fire_size','number_of_fires','all_fire_sizes','total_area_burned','severity_counts' ]
+metrics = [ 'veg_counts','avg_fire_size','number_of_fires','all_fire_sizes','total_area_burned' ]
 
 # # PostProcess
 # alfresco output gtiffs

--- a/readme.md
+++ b/readme.md
@@ -31,7 +31,7 @@ band descriptions:
 	2.) identifies each fire patch with a unique integer value patch count begins at 1.
 	3.) boolean value (0,1) where a fire's ignition point is 1.
 ```
-* BurnSeverity - [not yet supported]
+* BurnSeverity - Burn severity levels for each fire patch in an ALFRESCO Output FireScar file.
 
 * BasalArea - [not yet supported]
 
@@ -68,7 +68,7 @@ output_path = './ALFRESCO_PP'
 mod_json_fn = os.path.join( output_path, 'ALF.json' )
 obs_json_fn = os.path.join( output_path, 'OBS.json' )
 suffix = 'ModelName_scenario' # some id for the output csvs
-metrics = [ 'veg_counts','avg_fire_size','number_of_fires','all_fire_sizes','total_area_burned' ]
+metrics = [ 'veg_counts','avg_fire_size','number_of_fires','all_fire_sizes','total_area_burned', 'severity_counts' ]
 
 # # PostProcess
 # alfresco output gtiffs

--- a/readme.md
+++ b/readme.md
@@ -68,7 +68,7 @@ output_path = './ALFRESCO_PP'
 mod_json_fn = os.path.join( output_path, 'ALF.json' )
 obs_json_fn = os.path.join( output_path, 'OBS.json' )
 suffix = 'ModelName_scenario' # some id for the output csvs
-metrics = [ 'veg_counts','avg_fire_size','number_of_fires','all_fire_sizes','total_area_burned', 'severity_counts' ]
+metrics = [ 'veg_counts','avg_fire_size','number_of_fires','all_fire_sizes','total_area_burned','severity_counts' ]
 
 # # PostProcess
 # alfresco output gtiffs

--- a/readme.md
+++ b/readme.md
@@ -46,7 +46,7 @@ rasterio requires: `gdal` library development bindings for your system.
 ```bash
 # make sure that NumPy is installed first due to some dependency weirdness
 pip install numpy
-pip install git+https://github.com/ua-snap/alfresco-postprocessing/tree/alfresco_postprocessing
+pip install git+https://github.com/ua-snap/alfresco_postprocessing
 ```
 
 #### Basic Usage:

--- a/snap_scripts/example_run_ml.py
+++ b/snap_scripts/example_run_ml.py
@@ -11,11 +11,11 @@ historical_maps_path = '/Data/Base_Data/ALFRESCO/ALFRESCO_Master_Dataset/ALFRESC
 subdomains_fn = '/workspace/Shared/Users/jschroder/ALFRESCO_SERDP/Data/Domains/AOI_SERDP.shp'
 id_field = 'OBJECTID_1'
 name_field = 'Name'
-output_path = '/atlas_scratch/malindgren/TEST_WINSLOW'
+output_path = '/atlas_scratch/malindgren/TEST_BURNSEVERITY'
 mod_json_fn = os.path.join( output_path, 'ALF_TEST.json' )
 obs_json_fn = os.path.join( output_path, 'OBS_TEST.json' )
 suffix = 'GISS-E2-R_rcp85_NoFMO' # some id for the output csvs
-metrics = [ 'veg_counts','avg_fire_size','number_of_fires','all_fire_sizes','total_area_burned' ]
+metrics = [ 'veg_counts','avg_fire_size','number_of_fires','all_fire_sizes','total_area_burned','severity_counts' ]
 
 # # PostProcess
 # alfresco output gtiffs


### PR DESCRIPTION
Adds BurnSeverity `severity_counts` outputs to the standard outputs from the ALFPP run in both the JSON and CSV output formats.