### PR TITLE
Include ALFRESCO version number and flammability/vegetation info in GeoTIFF tags

### DIFF
--- a/bin/alfresco_relative_flammability.py
+++ b/bin/alfresco_relative_flammability.py
@@ -125,7 +125,7 @@ def relative_flammability(
 
         # Replace replicate info with a more general description for aggregate
         # GeoTIFFs.
-        tags["TIFFTAG_IMAGEDESCRIPTION"] = "Values represent flammability of the pixel."
+        tags["TIFFTAG_IMAGEDESCRIPTION"] = "Values represent flammability."
 
         out_rst.update_tags(**tags)
         out_rst.write(np.around(relative_flammability, 4), 1)

--- a/bin/alfresco_relative_flammability.py
+++ b/bin/alfresco_relative_flammability.py
@@ -114,6 +114,13 @@ def relative_flammability(
         pass
 
     with rasterio.open(output_filename, "w", **meta) as out_rst:
+        tags = tmp_rst.tags()
+
+        # Replace replicate info with a more general description for aggregate
+        # GeoTIFFs.
+        tags['TIFFTAG_IMAGEDESCRIPTION'] = 'Values represent flammability of the pixel.'
+
+        out_rst.update_tags(**tags)
         out_rst.write(np.around(relative_flammability, 4), 1)
 
     return output_filename

--- a/bin/alfresco_relative_flammability.py
+++ b/bin/alfresco_relative_flammability.py
@@ -4,8 +4,9 @@ Note - this script relies on a specific file organization structure
 
 import argparse
 import os
+
 # potential fix for "OpenBLAS blas_thread_init: pthread_create failed for thread . of 64: Resource temporarily unavailable" warnings
-os.environ['OPENBLAS_NUM_THREADS'] = '1'
+os.environ["OPENBLAS_NUM_THREADS"] = "1"
 import time
 import multiprocessing as mp
 from functools import partial
@@ -38,15 +39,16 @@ def run_group(group):
 
 def chunk_groups(group_list, n=50):
     """Split a list of filepath groups into smaller groups"""
+
     def chunk(l, n):
         # looping till length l
-        for i in range(0, len(l), n): 
-            yield l[i:i + n]
+        for i in range(0, len(l), n):
+            yield l[i : i + n]
 
     new_groups = []
     for group in group_list:
         new_groups.extend(chunk(group, n))
-        
+
     return new_groups
 
 
@@ -55,7 +57,7 @@ def sum_firescars(firescar_list, ncores):
     firescar_series = pd.Series(firescar_list)
     repgrouper = firescar_series.apply(get_repnum)
     firescar_groups = [j.tolist() for i, j in firescar_series.groupby(repgrouper)]
-    
+
     # Pool.map() is locking up with larger groups for some reason,
     # try splitting into smaller groups to improve success
     if len(firescar_groups[0]) > 50:
@@ -72,7 +74,12 @@ def sum_firescars(firescar_list, ncores):
 
 
 def relative_flammability(
-    firescar_list, output_filename, mask_arr, mask_value, ncores, crs=None,
+    firescar_list,
+    output_filename,
+    mask_arr,
+    mask_value,
+    ncores,
+    crs=None,
 ):
     """
     run relative flammability.
@@ -118,7 +125,7 @@ def relative_flammability(
 
         # Replace replicate info with a more general description for aggregate
         # GeoTIFFs.
-        tags['TIFFTAG_IMAGEDESCRIPTION'] = 'Values represent flammability of the pixel.'
+        tags["TIFFTAG_IMAGEDESCRIPTION"] = "Values represent flammability of the pixel."
 
         out_rst.update_tags(**tags)
         out_rst.write(np.around(relative_flammability, 4), 1)
@@ -133,10 +140,10 @@ if __name__ == "__main__":
     # ncores = 32
     # begin_year = 1900
     # end_year = 1999
-    
+
     # track time
     tic = time.perf_counter()
-    
+
     parser = argparse.ArgumentParser(
         description="program to calculate Relative Flammability from ALFRESCO"
     )
@@ -225,6 +232,6 @@ if __name__ == "__main__":
         ncores,
         crs={"init": "epsg:3338"},
     )
-    
+
     print(f"Relative flammability computed, results written to {output_filename}")
     print(f"Elapsed time: {round((time.perf_counter() - tic) / 60, 1)}m")

--- a/bin/vegetation_change_mode_and_percents.py
+++ b/bin/vegetation_change_mode_and_percents.py
@@ -112,12 +112,12 @@ def main(args):
 
     # Remove replicate information from aggregate GeoTIFFs, but preserve the
     # value index substring as-is for mode GeoTIFFs.
-    description = mode_tags['TIFFTAG_IMAGEDESCRIPTION']
-    value_index_string = re.search(r'Value Index:.*', description).group()
-    mode_tags['TIFFTAG_IMAGEDESCRIPTION'] = value_index_string
+    description = mode_tags["TIFFTAG_IMAGEDESCRIPTION"]
+    value_index_string = re.search(r"Value Index:.*", description).group()
+    mode_tags["TIFFTAG_IMAGEDESCRIPTION"] = value_index_string
 
     # Turn value index string into lookup dict for percent GeoTIFFs.
-    matches = re.findall(r'([0-9]+)\=([\w/ ]+)', value_index_string)
+    matches = re.findall(r"([0-9]+)\=([\w/ ]+)", value_index_string)
     veg_type_lu = dict(matches)
 
     print(f"Writing results to {filename}", end="...", flush=True)
@@ -142,17 +142,21 @@ def main(args):
 
             meta = rasterio.open(veg_list[0]).meta
             meta.update(
-                compress="lzw", dtype=np.float32, crs={"init": "EPSG:3338"}, nodata=-9999
+                compress="lzw",
+                dtype=np.float32,
+                crs={"init": "EPSG:3338"},
+                nodata=-9999,
             )
 
         veg_label = veg_type_lu[str(veg_type)]
-        description = 'Values represent the likelihood of {}.'.format(veg_label)
-        percent_tags['TIFFTAG_IMAGEDESCRIPTION'] = description
+        description = "Values represent the likelihood of {}.".format(veg_label)
+        percent_tags["TIFFTAG_IMAGEDESCRIPTION"] = description
         with rasterio.open(filename, "w", **meta) as out:
             out.update_tags(**percent_tags)
             out.write(percentages, 1)
 
     print(f"done, total time: {round((time.perf_counter() - tic) / 60, 1)}m")
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(

--- a/bin/vegetation_change_mode_and_percents.py
+++ b/bin/vegetation_change_mode_and_percents.py
@@ -1,6 +1,7 @@
 import argparse
 import glob
 import os
+import re
 import time
 from itertools import groupby
 import rasterio
@@ -89,7 +90,8 @@ def main(args):
         arr = rst.read(1)
         mode_grid[arr == 255] = -9999
 
-    meta = rasterio.open(veg_list[0]).meta
+    veg_example = rasterio.open(veg_list[0])
+    meta = veg_example.meta
     meta.update(
         compress="lzw", dtype=np.float32, crs={"init": "EPSG:3338"}, nodata=-9999
     )
@@ -105,8 +107,22 @@ def main(args):
     basename = os.path.basename(args.output_filename)
     filename = mode_dir + "/" + basename
 
+    mode_tags = veg_example.tags()
+    percent_tags = veg_example.tags()
+
+    # Remove replicate information from aggregate GeoTIFFs, but preserve the
+    # value index substring as-is for mode GeoTIFFs.
+    description = mode_tags['TIFFTAG_IMAGEDESCRIPTION']
+    value_index_string = re.search(r'Value Index:.*', description).group()
+    mode_tags['TIFFTAG_IMAGEDESCRIPTION'] = value_index_string
+
+    # Turn value index string into lookup dict for percent GeoTIFFs.
+    matches = re.findall(r'([0-9]+)\=([\w/ ]+)', value_index_string)
+    veg_type_lu = dict(matches)
+
     print(f"Writing results to {filename}", end="...", flush=True)
     with rasterio.open(filename, "w", **meta) as out:
+        out.update_tags(**mode_tags)
         out.write(mode_grid, 1)
 
     # Create list of eight 2D arrays, one 2D array for each vegetation type.
@@ -129,7 +145,11 @@ def main(args):
                 compress="lzw", dtype=np.float32, crs={"init": "EPSG:3338"}, nodata=-9999
             )
 
+        veg_label = veg_type_lu[str(veg_type)]
+        description = 'Values represent the likelihood of {}.'.format(veg_label)
+        percent_tags['TIFFTAG_IMAGEDESCRIPTION'] = description
         with rasterio.open(filename, "w", **meta) as out:
+            out.update_tags(**percent_tags)
             out.write(percentages, 1)
 
     print(f"done, total time: {round((time.perf_counter() - tic) / 60, 1)}m")


### PR DESCRIPTION
Closes #18.

This PR updates two of the post-processing scripts to:

- Retain the ALFRESCO version number string that is added as the `TIFFTAG_SOFTWARE` tag to GeoTIFFs produced by ALFRESCO
- Retain parts of the `TIFFTAG_IMAGEDESCRIPTION` GeoTIFF tag that are still relevant, like the vegetation type index, but strip out the stuff that is not relevant for aggregated GeoTIFFs. For example, it's not accurate to mention a replicate number in a GeoTIFF that combines all replicates into one product, so information like this is stripped out:

    > Vegetation Type for year 1950 of rep 22.

I've tried to make testing easy by putting everything you need in the `/atlas_scratch/crstephenson/pr_review` directory on Atlas. You should have write access to this directory, too, if you want to just run the Slurm job in the `pr_review` directory itself. Just remember to remove the `post` directory when you are done so it doesn't impact the other reviewer!

Once the Slurm job is done, run `gdalinfo` on the GeoTIFFs that get written into the `post` directory. Make sure the `TIFFTAG_SOFTWARE` and `TIFFTAG_IMAGEDESCRIPTION` tags for each of these three types of GeoTIFFs make sense:

- Flammability
- Vegetation mode
- Vegetation percent